### PR TITLE
fix: trim short bio only before submission, not during an edit

### DIFF
--- a/packages/velog-web/src/features/setting/components/SettingUserProfile/SettingUserProfile.tsx
+++ b/packages/velog-web/src/features/setting/components/SettingUserProfile/SettingUserProfile.tsx
@@ -106,7 +106,7 @@ function SettingUserProfile({ displayName, shortBio, thumbnail }: Props) {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     await updateProfileMutateAsync({
-      input: { display_name: inputs.displayName, short_bio: inputs.shortBio },
+      input: { display_name: inputs.displayName, short_bio: inputs.shortBio.trim() },
     })
     onToggleEdit()
     currentUserRefetch()

--- a/packages/velog-web/src/hooks/useInputs.ts
+++ b/packages/velog-web/src/hooks/useInputs.ts
@@ -26,7 +26,7 @@ export default function useInputs<T extends Record<string, any>>(defaultValues: 
   const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({
       name: e.target.name,
-      value: e.target.value.trim(),
+      value: e.target.value,
     })
   }, [])
   const onReset = useCallback(() => {


### PR DESCRIPTION
프로필 한 줄 소개를 입력하는 동안에 스페이스를 눌러 마지막 단어 뒤에 공백을 삽입하는 경우, controlled state가 즉시 trim()되어서 스페이스가 입력되지 않는 것처럼 보이는 현상이 있습니다. trim() 시점을 submit 직전으로 이동시켜, 더 나은 편집 경험을 누릴 수 있게 합니다.