### PR TITLE
fix: '알림' 글자의 color css 올바르게 설정

### DIFF
--- a/apps/web/src/features/notification/components/NotificationTitle/NotificationTitle.module.css
+++ b/apps/web/src/features/notification/components/NotificationTitle/NotificationTitle.module.css
@@ -4,3 +4,7 @@
   font-size: 32px;
   font-weight: 700;
 }
+
+.title {
+  color: var(--text2);
+}

--- a/apps/web/src/features/notification/components/NotificationTitle/NotificationTitle.tsx
+++ b/apps/web/src/features/notification/components/NotificationTitle/NotificationTitle.tsx
@@ -23,7 +23,11 @@ function NotificationTitle({}: Props) {
     refetch()
   }, [data, mutate, refetch])
 
-  return <div className={cx('block')}>알림</div>
+  return (
+    <div className={cx('block')}>
+      <div className={cx('title')}>알림</div>
+    </div>
+  )
 }
 
 export default NotificationTitle


### PR DESCRIPTION
<img width="648" alt="image" src="https://github.com/user-attachments/assets/eb623c31-a14c-4136-a383-22fb361c3dd6">
<img width="648" alt="image" src="https://github.com/user-attachments/assets/86cb3120-c308-431e-a7e2-ff13ad46d8a2">

알림 페이지에서 '알림' 글자의 색이 고정되어 화이트 theme 에선 보이지 않는 이슈를 해결하기 위해 PR을 생성합니다.

감사합니다.
